### PR TITLE
Dark Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules/
+dist/

--- a/browser.js
+++ b/browser.js
@@ -64,6 +64,15 @@ function init() {
   backButton();
 }
 
+function setDarkMode() {
+	document.documentElement.classList.toggle('dark-mode', config.get('darkMode'));
+    console.log(document.documentElement);
+}
+
+ipcRenderer.on('toggle-dark-mode', () => {
+	config.set('darkMode', !config.get('darkMode'));
+	setDarkMode();
+});
 
 document.addEventListener('DOMContentLoaded', (event) => {
   // enable OS specific styles
@@ -71,4 +80,13 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
   elementReady(selectors.root).then(init);
   elementReady(selectors.loginButton).then(login);
+
+  setDarkMode();
+
+  // prevent flash of white on startup when in dark mode
+  // TODO: find a CSS only solution
+  if (config.get('darkMode')) {
+      document.documentElement.style.backgroundColor = '#192633';
+  }
+
 });

--- a/browser.js
+++ b/browser.js
@@ -66,7 +66,11 @@ function init() {
 
 function setDarkMode() {
 	document.documentElement.classList.toggle('dark-mode', config.get('darkMode'));
-    console.log(document.documentElement);
+    if (config.get('darkMode')) {
+        document.documentElement.style.backgroundColor = '#192633';
+    } else {
+        document.documentElement.style.backgroundColor = '#FFF';        
+    }
 }
 
 ipcRenderer.on('toggle-dark-mode', () => {
@@ -85,8 +89,6 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
   // prevent flash of white on startup when in dark mode
   // TODO: find a CSS only solution
-  if (config.get('darkMode')) {
-      document.documentElement.style.backgroundColor = '#192633';
-  }
+
 
 });

--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@ const Config = require('electron-config');
 
 module.exports = new Config({
   defaults: {
-    darkMode: false,
+    darkMode: true,
     zoomFactor: 1,
     lastWindowState: {
       width: 414,

--- a/dark-browser.css
+++ b/dark-browser.css
@@ -1,0 +1,32 @@
+html.dark-mode::-webkit-scrollbar-track { background-color: #192633; }
+html.dark-mode::-webkit-scrollbar-thumb { background-color: #fff; }
+
+/* Add sidebar */
+html.dark-mode#react-root ._onabe._kjy2s {
+  background-color: #192633;
+  border-right: 1px solid rgba(255,255,255,.08);
+}
+
+/* Very top rectangle of icon list */
+html.dark-mode#react-root ._4kdxu {
+    background-color: #192633;
+}
+
+/* Icons list */
+html.dark-mode #react-root ._n7q2c {
+  background-color: #192633;
+}
+/* Icon Item */
+html.dark-mode #react-root ._r1svv {
+  -webkit-filter: brightness(0) invert(1);
+}
+
+/* Back Button */
+html.dark-mode .back-btn {
+  background-color: #192633;
+  border-top: 1px solid rgba(255, 255, 255, 0.0784314);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.0784314);
+}
+
+html.dark-mode .back-btn svg { fill: #fff; }
+html.dark-mode .back-btn.inactive svg { fill: rgba(255, 255, 255, 0.4);  }

--- a/dark-browser.css
+++ b/dark-browser.css
@@ -1,27 +1,27 @@
 html.dark-mode::-webkit-scrollbar-track { background-color: #192633; }
 html.dark-mode::-webkit-scrollbar-thumb { background-color: #fff; }
 
-/* Add sidebar */
+/*
+    Sidebar Darkening
+*/
+
 html.dark-mode #react-root ._onabe._kjy2s {
   background-color: #192633;
   border-right: 1px solid rgba(255,255,255,.08);
 }
 
-/* Very top rectangle of icon list */
 html.dark-mode #react-root ._4kdxu {
     background-color: #192633;
 }
 
-/* Icons list */
 html.dark-mode #react-root ._n7q2c {
   background-color: #192633;
 }
-/* Icon Item */
+
 html.dark-mode #react-root ._r1svv {
   -webkit-filter: brightness(0) invert(1);
 }
 
-/* Back Button */
 html.dark-mode .back-btn {
   background-color: #192633;
   border-top: 1px solid rgba(255, 255, 255, 0.0784314);
@@ -30,3 +30,27 @@ html.dark-mode .back-btn {
 
 html.dark-mode .back-btn svg { fill: #fff; }
 html.dark-mode .back-btn.inactive svg { fill: rgba(255, 255, 255, 0.2);  }
+
+/*
+    Login
+*/
+
+html.dark-mode #react-root ._6ltyr._1wptv {
+    background-color: #192633;
+}
+
+html.dark-mode #react-root ._p8ymb {
+    background-color: #192633;
+}
+
+html.dark-mode #react-root ._du7bh {
+  -webkit-filter: brightness(0) invert(1);
+}
+
+html.dark-mode #react-root ._nvyyp {
+    background-color: #192633;
+}
+
+html.dark-mode #react-root ._kp5f7._qy55y {
+    color: white;
+}

--- a/dark-browser.css
+++ b/dark-browser.css
@@ -2,13 +2,13 @@ html.dark-mode::-webkit-scrollbar-track { background-color: #192633; }
 html.dark-mode::-webkit-scrollbar-thumb { background-color: #fff; }
 
 /* Add sidebar */
-html.dark-mode#react-root ._onabe._kjy2s {
+html.dark-mode #react-root ._onabe._kjy2s {
   background-color: #192633;
   border-right: 1px solid rgba(255,255,255,.08);
 }
 
 /* Very top rectangle of icon list */
-html.dark-mode#react-root ._4kdxu {
+html.dark-mode #react-root ._4kdxu {
     background-color: #192633;
 }
 
@@ -29,4 +29,4 @@ html.dark-mode .back-btn {
 }
 
 html.dark-mode .back-btn svg { fill: #fff; }
-html.dark-mode .back-btn.inactive svg { fill: rgba(255, 255, 255, 0.4);  }
+html.dark-mode .back-btn.inactive svg { fill: rgba(255, 255, 255, 0.2);  }

--- a/dark-browser.css
+++ b/dark-browser.css
@@ -2,7 +2,7 @@ html.dark-mode::-webkit-scrollbar-track { background-color: #192633; }
 html.dark-mode::-webkit-scrollbar-thumb { background-color: #fff; }
 
 /*
-    Sidebar Darkening
+    Sidebar
 */
 
 html.dark-mode #react-root ._onabe._kjy2s {
@@ -53,4 +53,87 @@ html.dark-mode #react-root ._nvyyp {
 
 html.dark-mode #react-root ._kp5f7._qy55y {
     color: white;
+}
+
+/*
+    Content
+*/
+
+
+/* Suggestions */
+
+html.dark-mode #react-root ._cag6k._4j13h {
+    background-color: #202C3A;
+}
+
+html.dark-mode #react-root ._4zhc5 {
+    color: #bbb;
+}
+
+html.dark-mode #react-root ._2uju6 {
+    color: #bbb;
+}
+
+html.dark-mode #react-root ._bgfey {
+    color: #ddd;
+}
+
+/* Main */
+
+html.dark-mode #react-root ._kul9p._rnlnu {
+    color: #bbb;
+}
+
+html.dark-mode #react-root ._tf9x3 {
+    color: #ddd;
+}
+
+html.dark-mode #react-root ._nk46a span {
+    color: #bbb;
+}
+
+html.dark-mode #react-root ._nk46a span a {
+    color: #0096CA;
+}
+
+/* Profile */
+
+html.dark-mode #react-root ._i572c {
+    color: #bbb;
+}
+
+html.dark-mode #react-root ._79dar {
+    color: #bbb;
+}
+
+html.dark-mode #react-root ._bugdy span {
+    color: #bbb;
+}
+
+html.dark-mode #react-root ._s53mj._13vpi {
+    color: #ddd;
+}
+
+html.dark-mode #react-root ._bkw5z._kjym7 {
+    color: #ddd;
+}
+
+/* Notifications (likes) */
+
+html.dark-mode #react-root ._auspy {
+        color: #bbb;
+}
+
+/* Tableviews (Following, Followers) */
+
+html.dark-mode #react-root ._7z4zb {
+}
+
+html.dark-mode #react-root ._q44m8 {
+    background-color: #202C3A;
+    color: #ddd;
+}
+
+html.dark-mode #react-root ._cx1ua {
+    background-color: #202C3A;    
 }

--- a/dark-browser.css
+++ b/dark-browser.css
@@ -78,6 +78,10 @@ html.dark-mode #react-root ._bgfey {
     color: #ddd;
 }
 
+html.dark-mode #react-root ._cag6k {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.4);
+}
+
 /* Main */
 
 html.dark-mode #react-root ._kul9p._rnlnu {
@@ -94,6 +98,10 @@ html.dark-mode #react-root ._nk46a span {
 
 html.dark-mode #react-root ._nk46a span a {
     color: #0096CA;
+}
+
+html.dark-mode #react-root ._jveic {
+    border-top: 1px solid rgba(255, 255, 255, 0.4);
 }
 
 /* Profile */
@@ -126,14 +134,22 @@ html.dark-mode #react-root ._auspy {
 
 /* Tableviews (Following, Followers) */
 
-html.dark-mode #react-root ._7z4zb {
-}
-
 html.dark-mode #react-root ._q44m8 {
     background-color: #202C3A;
     color: #ddd;
 }
 
 html.dark-mode #react-root ._cx1ua {
-    background-color: #202C3A;    
+    background-color: #202C3A;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+/* Search */
+
+html.dark-mode #react-root ._oyz6j {
+    background-color: #202C3A;
+}
+
+html.dark-mode #react-root ._55bi1 {
+    background-color: #202C3A;
 }

--- a/main.js
+++ b/main.js
@@ -32,6 +32,7 @@ if (isAlreadyRunning) {
 
 function createMainWindow () {
   const lastWindowState = config.get('lastWindowState');
+  const isDarkMode = config.get('darkMode');
   const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1';
   const maxWidthValue = 550;
   const minWidthValue = 400;
@@ -51,7 +52,8 @@ function createMainWindow () {
     fullscreenable: false,
     icon: process.platform === 'linux' && path.join(__dirname, 'static/icon.png'),
     titleBarStyle: 'hidden-inset',
-    backgroundColor: '#fff',
+	darkTheme: isDarkMode,
+    backgroundColor: isDarkMode ? '#192633' : '#ff',
     autoHideMenuBar: true,
     webPreferences: {
       preload: path.join(__dirname, 'browser.js'),
@@ -112,6 +114,7 @@ app.on('ready', () => {
 
   page.on('dom-ready', () => {
     page.insertCSS(fs.readFileSync(path.join(__dirname, 'browser.css'), 'utf8'));
+    page.insertCSS(fs.readFileSync(path.join(__dirname, 'dark-browser.css'), 'utf8'));
     mainWindow.show();
   });
 

--- a/menu.js
+++ b/menu.js
@@ -169,6 +169,13 @@ if (process.platform === 'darwin') {
       {
         role: 'about'
       },
+	{
+		label: 'Toggle Dark Mode',
+		accelerator: 'Cmd+D',
+		click() {
+			sendAction('toggle-dark-mode');
+		}
+	},
       {
         type: 'separator'
       },


### PR DESCRIPTION
+ Added Dark Mode: Either via CMD + D or clicking the app name and Dark mode (Mac only) will change the theme to a dark theme. This feature is similar to the feature in [Caprine](https://github.com/sindresorhus/caprine). Right now, the only things that don't darken are the options in the users profile (changing name, etc.) and the pop-up menus (to be discussed?).

+ .gitignore for Mac files (not sure if needed)

(Tested on Mac OS X 10.11.5)