### PR TITLE
added update check

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ const electron = require('electron');
 const appMenu  = require('./menu');
 const config   = require('./config');
 const tray     = require('./tray');
+const version  = require('./version');
 
 const app      = electron.app;
 const ipcMain  = electron.ipcMain;
@@ -123,6 +124,8 @@ app.on('ready', () => {
     e.preventDefault();
     electron.shell.openExternal(url);
   });
+
+  setTimeout(function() {version.check()}, 10000);
 });
 
 app.on('activate', () => {

--- a/main.js
+++ b/main.js
@@ -125,7 +125,7 @@ app.on('ready', () => {
     electron.shell.openExternal(url);
   });
 
-  setTimeout(function() {version.check()}, 10000);
+  setTimeout(function() {version.check()}, 8000);
 });
 
 app.on('activate', () => {

--- a/menu.js
+++ b/menu.js
@@ -2,6 +2,7 @@
 const os = require('os');
 const path = require('path');
 const electron = require('electron');
+const version  = require('./version');
 
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow
@@ -31,6 +32,15 @@ function goBack() {
 }
 
 const helpSubmenu = [
+  {
+    label: 'Check for Updates...',
+    click() {
+      version.check();
+    }
+  },
+  {
+    type: 'separator'
+  },
   {
     label: `${appName} Website`,
     click() {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "electron-config": "^0.2.1",
     "electron-debug": "^1.0.1",
-    "element-ready": "^0.2.0",
-    "request": "^2.74.0"
+    "element-ready": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "electron-config": "^0.2.1",
     "electron-debug": "^1.0.1",
-    "element-ready": "^0.2.0"
+    "element-ready": "^0.2.0",
+    "request": "^2.74.0"
   }
 }

--- a/version.js
+++ b/version.js
@@ -1,0 +1,28 @@
+'use strict';
+const electron = require('electron');
+const request = require('request');
+const shell = electron.shell;
+
+const app = electron.app;
+
+exports.check = function() {
+  request.get('https://raw.githubusercontent.com/terkelg/ramme/master/package.json', function (error, response, body) {
+    if (!error && response.statusCode == 200) {
+        var versionJson = JSON.parse(body);
+        var newestVersion = versionJson.version;
+        if (newestVersion > app.getVersion()) {
+          var versionMessage = electron.dialog.showMessageBox({
+            type: 'info',
+            title: `Update available`,
+            message: `${app.getName()} ${newestVersion} is available`,
+            buttons: [`Download now`, 'Remind me later'],
+            cancelId: 3
+          });
+
+          if (versionMessage === 0) {
+            shell.openExternal('https://github.com/terkelg/ramme/releases');
+          };
+        }
+    }
+  });
+};

--- a/version.js
+++ b/version.js
@@ -1,14 +1,15 @@
 'use strict';
 const electron = require('electron');
-const request = require('request');
-const shell = electron.shell;
+const https = require('https');
 
+const shell = electron.shell;
 const app = electron.app;
 
 exports.check = function() {
-  request.get('https://raw.githubusercontent.com/terkelg/ramme/master/package.json', function (error, response, body) {
-    if (!error && response.statusCode == 200) {
-        var versionJson = JSON.parse(body);
+  https.get('https://raw.githubusercontent.com/terkelg/ramme/master/package.json', (res) => {
+    if (!res.error && res.statusCode == 200) {
+      res.on('data', (d) => {
+        var versionJson = JSON.parse(d);
         var newestVersion = versionJson.version;
         if (newestVersion > app.getVersion()) {
           var versionMessage = electron.dialog.showMessageBox({
@@ -18,11 +19,11 @@ exports.check = function() {
             buttons: [`Download now`, 'Remind me later'],
             cancelId: 3
           });
-
           if (versionMessage === 0) {
             shell.openExternal('https://github.com/terkelg/ramme/releases');
           };
-        }
-    }
+        };
+      });
+    };
   });
 };


### PR DESCRIPTION
added update check

- compares the `version` value in terkelg/ramme/master/package.json against `app.getVersion()`
- displays dialog with option to download (opens [Releases](https://github.com/terkelg/ramme/releases) in browser) or ignore
- runs automatically on app start (with 10s delay to allow app to fully render, because [dialog.showMessageBox](http://electron.atom.io/docs/api/dialog/#dialogshowmessageboxbrowserwindow-options-callback) will block the process until the message box is closed)
- manual check for update via help menu

![dialog](https://i.imgur.com/qXcyPJW.jpg)
![help menu](https://i.imgur.com/jdJz2uh.png)