### PR TITLE
Fix following/follow/edit profile buttons color in dark mode

### DIFF
--- a/app/src/renderer/styles/theme-dark/_profile.scss
+++ b/app/src/renderer/styles/theme-dark/_profile.scss
@@ -46,6 +46,11 @@ html.dark-mode #react-root ._bkw5z._kjym7 {
   color: $bright;
 }
 
+/* follow/following/edit profile buttons */
+html.dark-mode #react-root ._dzx3o {
+  color: $bright;
+}
+
 /* profile picture */
 html.dark-mode #react-root ._8gpiy {
   border-color: $dark;


### PR DESCRIPTION
Just a teeny-tiny `css` change to make the button readable

## Before
![before](http://i.imgur.com/rydftjb.pngl)

## After
![after](http://i.imgur.com/ZmAODfN.png)