### PR TITLE
Add preload window and window manager

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const {app, Menu, shell, ipcMain} = require('electron')
 const tray = require('./tray')
 const appMenu = require('./menus')
-const config = require('./config')
+
 const updater = require('./updater')
 const analytics = require('./analytics')
 const isPlatform = require('./../common/is-platform')
@@ -22,7 +22,7 @@ require('electron-debug')({
  * Register Windows
  */
 
-window.register("main", {
+window.register('main', {
   url: 'https://www.instagram.com/',
   useLastState: true,
   fakeUserAgent: true,
@@ -38,7 +38,18 @@ window.register("main", {
   webPreferences: {
     preload: path.join(__dirname, renderer.js, 'index.js'),
     nodeIntegration: false
-  },
+  }
+})
+
+window.register('preload', {
+  url: path.join('file://', __dirname, '../renderer/html/preload.html'),
+  useLastState: true,
+  width: 200,
+  height: 400,
+  resizable: false,
+  fullscreenable: false,
+  maximizable: false,
+  frame: false
 })
 
 /**
@@ -62,8 +73,11 @@ if (shouldQuit && window.countOpen() > 0) {
  * Kick off!
  */
 app.on('ready', () => {
+  // Open preload window
+  window.open('preload')
+
   // Open main window
-  let mainWindow = window.open("main")
+  let mainWindow = window.open('main')
   setupWindowEvents(mainWindow)
 
   // Create menus
@@ -79,7 +93,7 @@ app.on('ready', () => {
 })
 
 app.on('activate', () => {
-  window.get("main").show()
+  window.get('main').show()
 })
 
 app.on('before-quit', () => {
@@ -139,7 +153,9 @@ function setupWebContentsEvents (page) {
   page.on('dom-ready', () => {
     page.insertCSS(fs.readFileSync(path.join(__dirname, renderer.styles, 'app.css'), 'utf8'))
     page.insertCSS(fs.readFileSync(path.join(__dirname, renderer.styles, 'theme-dark/main.css'), 'utf8'))
-    window.get("main").show()
+
+    window.close('preload') // Close preload window
+    window.get('main').show() // Show main window
   })
 
   // Open links in external applications

--- a/app/src/main/window.js
+++ b/app/src/main/window.js
@@ -7,8 +7,8 @@ const isPlatform = require('./../common/is-platform')
  * API
  */
 
-let registered_windows = {}
-let current_windows = {}
+let registeredWindows = {}
+let currentWindows = {}
 
 // [function] Register Window
 function registerWindow (name, def) {
@@ -24,12 +24,12 @@ function registerWindow (name, def) {
   delete def.defaultWindowEvents
   delete def.url
 
-  def.icon = isPlatform('linux') && path.join(__dirname, '../assets/icon.png'),
+  def.icon = isPlatform('linux') ? path.join(__dirname, '../assets/icon.png') : null
   def.title = def.title || app.getName()
   def.darkTheme = isDarkMode
   def.backgroundColor = isDarkMode ? '#192633' : '#fff'
 
-  registered_windows[name] = {
+  registeredWindows[name] = {
     'def': def,
     'options': {
       url: url,
@@ -44,12 +44,12 @@ function registerWindow (name, def) {
 
 // [function] Open Window
 function openWindow (name) {
-  if (registered_windows[name]) {
-    const wanted = registered_windows[name]
+  if (registeredWindows[name]) {
+    const wanted = registeredWindows[name]
 
     // Restore window size if useLastState
     if (wanted.options.useLastState) {
-      const lastWindowState = config.get(name + "LastState")
+      const lastWindowState = config.get(name + 'LastState')
       wanted.def.x = lastWindowState.x
       wanted.def.y = lastWindowState.y
       wanted.def.width = lastWindowState.width
@@ -63,11 +63,6 @@ function openWindow (name) {
         win.webContents.setUserAgent(wanted.options.agent)
       }
 
-      // Create eventd if enabled
-      if (wanted.options.defaultWindowEvents) {
-        setupWindowEvents(win)
-      }
-
       // Load URL
       if (wanted.options.url) {
         win.loadURL(wanted.options.url)
@@ -76,17 +71,17 @@ function openWindow (name) {
       // Add save size event
       if (wanted.options.useLastState) {
         win.on('close', e => {
-          config.set(name + "LastState", win.getBounds())
+          config.set(name + 'LastState', win.getBounds())
         })
       }
 
       // Add de-reference event
       win.on('closed', e => {
-        delete current_windows[name]
+        delete currentWindows[name]
       })
 
       // Setup reference
-      current_windows[name] = win
+      currentWindows[name] = win
 
       return win
     }
@@ -95,44 +90,44 @@ function openWindow (name) {
 
 // [function] Get window
 function getWindow (name) {
-  if (current_windows[name]) {
-    return current_windows[name]
+  if (currentWindows[name]) {
+    return currentWindows[name]
   }
 }
 
 // [function] Window(s) is/are open
 function isOpen (name) {
-  if (name && current_windows[name]) {
+  if (name && currentWindows[name]) {
     return true
   }
 }
 
 // [function] Count open windows
 function countOpen () {
-  return Object.keys(current_windows).length
+  return Object.keys(currentWindows).length
 }
 
 // [function] Close window
 function closeWindow (name) {
-  if (current_windows[name]) {
-    current_windows[name].close()
+  if (currentWindows[name]) {
+    currentWindows[name].close()
     return true
   }
 }
 
 // [function] LoadURL
 function loadURL (name, url) {
-  if (current_windows[name] && url) {
-    current_windows[name].loadURL(url)
+  if (currentWindows[name] && url) {
+    currentWindows[name].loadURL(url)
   }
 }
 
 // [function] For each window
 function each (func) {
   if (countOpen() > 0) {
-    for (var name in current_windows) {
-      if (current_windows.hasOwnProperty(name)) {
-        func(current_windows[name])
+    for (var name in currentWindows) {
+      if (currentWindows.hasOwnProperty(name)) {
+        func(currentWindows[name])
       }
     }
     return true

--- a/app/src/main/window.js
+++ b/app/src/main/window.js
@@ -1,0 +1,171 @@
+const path = require('path')
+const {app, BrowserWindow, ipcMain} = require('electron')
+const config = require('./config')
+const isPlatform = require('./../common/is-platform')
+
+/**
+ * API
+ */
+
+let registered_windows = {}
+let current_windows = {}
+
+// [function] Register Window
+function registerWindow (name, def) {
+  const url = def.url
+  const useLastState = def.useLastState
+  const fakeUserAgent = def.fakeUserAgent
+  const defaultWindowEvents = def.defaultWindowEvents
+  const isDarkMode = config.get('darkMode') || false
+  const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
+
+  delete def.useLastState
+  delete def.fakeUserAgent
+  delete def.defaultWindowEvents
+  delete def.url
+
+  def.icon = isPlatform('linux') && path.join(__dirname, '../assets/icon.png'),
+  def.title = def.title || app.getName()
+  def.darkTheme = isDarkMode
+  def.backgroundColor = isDarkMode ? '#192633' : '#fff'
+
+  registered_windows[name] = {
+    'def': def,
+    'options': {
+      url: url,
+      agent: fakeUserAgent ? userAgent : null,
+      defaultWindowEvents: defaultWindowEvents,
+      useLastState: useLastState
+    }
+  }
+
+  return true
+}
+
+// [function] Open Window
+function openWindow (name) {
+  if (registered_windows[name]) {
+    const wanted = registered_windows[name]
+
+    // Restore window size if useLastState
+    if (wanted.options.useLastState) {
+      const lastWindowState = config.get(name + "LastState")
+      wanted.def.x = lastWindowState.x
+      wanted.def.y = lastWindowState.y
+      wanted.def.width = lastWindowState.width
+      wanted.def.height = lastWindowState.height
+    }
+
+    const win = new BrowserWindow(wanted.def)
+
+    if (win) {
+      if (wanted.options.agent) {
+        win.webContents.setUserAgent(wanted.options.agent)
+      }
+
+      // Create eventd if enabled
+      if (wanted.options.defaultWindowEvents) {
+        setupWindowEvents(win)
+      }
+
+      // Load URL
+      if (wanted.options.url) {
+        win.loadURL(wanted.options.url)
+      }
+
+      // Add save size event
+      if (wanted.options.useLastState) {
+        win.on('close', e => {
+          config.set(name + "LastState", win.getBounds())
+        })
+      }
+
+      // Add de-reference event
+      win.on('closed', e => {
+        delete current_windows[name]
+      })
+
+      // Setup reference
+      current_windows[name] = win
+
+      return win
+    }
+  }
+}
+
+// [function] Get window
+function getWindow (name) {
+  if (current_windows[name]) {
+    return current_windows[name]
+  }
+}
+
+// [function] Window(s) is/are open
+function isOpen (name) {
+  if (name && current_windows[name]) {
+    return true
+  }
+}
+
+// [function] Count open windows
+function countOpen () {
+  return Object.keys(current_windows).length
+}
+
+// [function] Close window
+function closeWindow (name) {
+  if (current_windows[name]) {
+    current_windows[name].close()
+    return true
+  }
+}
+
+// [function] LoadURL
+function loadURL (name, url) {
+  if (current_windows[name] && url) {
+    current_windows[name].loadURL(url)
+  }
+}
+
+// [function] For each window
+function each (func) {
+  if (countOpen() > 0) {
+    for (var name in current_windows) {
+      if (current_windows.hasOwnProperty(name)) {
+        func(current_windows[name])
+      }
+    }
+    return true
+  }
+}
+
+/**
+ * IPC
+ */
+
+ipcMain.on('window-open', function (event, name) {
+  openWindow(name)
+})
+
+ipcMain.on('window-close', function (event, name) {
+  closeWindow(name)
+})
+
+ipcMain.on('window-load', function (event, name, url) {
+  loadURL(name, url)
+})
+
+/**
+ * Exposed Functions
+ */
+
+module.exports = {
+  register: registerWindow,
+  open: openWindow,
+  get: getWindow,
+  isOpen: isOpen,
+  countOpen: countOpen,
+  close: closeWindow,
+  load: loadURL,
+  each: each
+}

--- a/app/src/renderer/html/preload.html
+++ b/app/src/renderer/html/preload.html
@@ -1,0 +1,24 @@
+<html>
+  <head>
+    <link rel='stylesheet' href='../styles/preload/main.css'>
+  </head>
+
+  <body>
+    <img id='icon' src='../../assets/icon.png'>
+    <div id='progress'></div>
+    <p id='text'>Loading...</p>
+  </body>
+</html>
+
+<script>
+const config = require('../../main/config')
+// Dark mode
+document.documentElement.classList.toggle('dark-mode', config.get('darkMode'))
+
+// Loading '.' iterator
+var i = 0;
+setInterval(function () {
+  i = ++i % 4;
+  document.getElementById('text').innerHTML = 'Loading' + Array(i + 1).join('.')
+}, 500)
+</script>

--- a/app/src/renderer/styles/preload/main.scss
+++ b/app/src/renderer/styles/preload/main.scss
@@ -1,0 +1,46 @@
+html {
+  -webkit-app-region: drag;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+}
+
+#icon {
+  width: 50%;
+  margin: 25%;
+}
+
+#text {
+  position: relative;
+  left: calc(50% - 29px);
+  width: 48px;
+  font-size: 0.8rem;
+  color: #535353;
+}
+
+html.dark-mode {
+  background-color: #192633;
+}
+
+html.dark-mode #text {
+  color: #ACACAC;
+}
+
+/* Progress Bar */
+
+@keyframes rainbow {
+  0% { background-position: 0% 100%; }
+  50% { background-position: 100% 200%; }
+  100% {background-position: 0% 100%; }
+}
+
+#progress {
+  height: 4px;
+  width: 90%;
+  margin: 5%;
+
+  background: linear-gradient(124deg, #ff2400, #e8b71d, #e3e81d, #1de840, #1ddde8, #2b1de8, #dd00f3);
+  background-size: 900% 900%;
+  border: 0px solid white;
+  border-radius: 10px;
+
+  animation: rainbow 9s linear infinite;
+}


### PR DESCRIPTION
![ramme preload both](https://user-images.githubusercontent.com/15371866/29500501-f4da8ebc-85d5-11e7-9f31-f3a091eee7a9.png)

This PR adds a preload window which is shown while the main window is loading the main Instagram website, and closed once the main window is shown (i.e. when the DOM is ready). The loading bar visible in the screenshot is animated not unlike the bar that is shown at the top of the Instagram website when switching between pages.

In order to achieve this functionality, I've entirely replaced the old window creation functions with a sort of window manager library, that allows registering windows to be opened or closed at a later time - these windows can even be managed to some extent via IPC. To get an idea of what the window manager does, take a look at the end of the `app/src/main/window.js` file.

This PR also *seems* to fix an issue I've noticed that seems to cause the window to quit during the "singleton" at times when it should not.

### Testing

When testing this PR, I'd suggest that you comment out line 17-19 (shows debug tools), as the preload window is not resizable causing developer tools to make it hard to view. If you'd like to prevent the preload window from closing so fast, comment out line 157. In order to make the window resizable, comment out line 46 and line 49.