### PR TITLE
Ignore .sass-cache, *.css, and *.css.map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 dist/
 npm-debug.log
 *.swp
+.sass-cache
+*.css
+*.css.map


### PR DESCRIPTION
.sass-cache and *.css.map files are generated automatically by the sass
gem package and should not be tracked by git. *.css files do not seem to
be included in git either, so I've added them to the .gitignore as well.