### PR TITLE
Do not automatically open debug tools

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,6 @@
   ],
   "dependencies": {
     "electron-config": "^1.0.0",
-    "electron-debug": "^1.1.0",
     "electron-is-dev": "^0.1.2",
     "element-ready": "^1.0.0",
     "first-run": "^1.2.0",

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -14,10 +14,6 @@ const renderer = {
   js: '../renderer/js'
 }
 
-require('electron-debug')({
-  showDevTools: true
-})
-
 /**
  * Register Windows
  */

--- a/app/src/main/menus.js
+++ b/app/src/main/menus.js
@@ -193,6 +193,22 @@ const template = [{
       sendAction('toggle-dark-mode')
     }
   },
+  {
+    label: 'Toggle Developer Tools',
+    type: 'checkbox',
+    accelerator: (function () {
+      if (process.platform === 'darwin') {
+        return 'Alt+Command+I'
+      } else {
+        return 'Ctrl+Shift+I'
+      }
+    })(),
+    click: function (item, focusedWindow) {
+      if (focusedWindow) {
+        focusedWindow.toggleDevTools()
+      }
+    }
+  }
   ]
 },
 {


### PR DESCRIPTION
This PR replaces the dependency to `electron-debug` which caused the developer debug tools to be automatically opened at window creation with a menu entry under the `View` section (triggered with `Ctrl+Shift+I` on Windows/Linux or `Alt+Shift+I` on MacOS).

This is an improvement to the previous functionality as I have personally found myself having to close the developer debug tools almost every single time I launch a developer version of the application. Not only that, but considering the higher limitations to resizing placed on Ramme's windows, it can at times be impossible to close the debug tool with too small a window.

TL;DR: Automatically opening developer debug tools was annoying; this PR removes the feature and replaces it with the ability to easily open debug tools when *you* want to.