### PR TITLE
Improve UI

### DIFF
--- a/app/src/main/menus.js
+++ b/app/src/main/menus.js
@@ -2,6 +2,7 @@ const os = require('os')
 const path = require('path')
 const isPlatform = require('./../common/is-platform')
 const {app, BrowserWindow, Menu, shell, dialog, nativeImage} = require('electron')
+const config = require('./config')
 
 const appName = app.getName()
 
@@ -164,25 +165,6 @@ const template = [{
     }
   },
   {
-    label: 'Toggle Dark Mode',
-    accelerator: 'CmdOrCtrl+D',
-    click () {
-      sendAction('toggle-dark-mode')
-    }
-  },
-  {
-    type: 'separator'
-  },
-  {
-    role: 'resetzoom'
-  },
-  {
-    role: 'zoomin'
-  },
-  {
-    role: 'zoomout'
-  },
-  {
     type: 'separator'
   },
   {
@@ -198,7 +180,19 @@ const template = [{
     click () {
       sendAction('navigate-down')
     }
-  }
+  },
+  {
+    type: 'separator'
+  },
+  {
+    type: 'checkbox',
+    checked: config.get('darkMode'),
+    label: 'Toggle Dark Mode',
+    accelerator: 'CmdOrCtrl+D',
+    click () {
+      sendAction('toggle-dark-mode')
+    }
+  },
   ]
 },
 {

--- a/app/src/renderer/js/index.js
+++ b/app/src/renderer/js/index.js
@@ -7,49 +7,42 @@ const $ = document.querySelector.bind(document)
 
 var post = 0
 
-const selectors = {
-  root: '#react-root ._onabe',
-  loginButton: '#react-root ._fcn8k',
-  notFoundPage: '.dialog-404'
-}
-
 ipcRenderer.on('toggle-dark-mode', () => {
   config.set('darkMode', !config.get('darkMode'))
   setDarkMode()
-  document.location.reload()
 })
 
 ipcRenderer.on('navigate-home', () => {
-  const home = $('._n7q2c ._r1svv:nth-child(1) a')
+  const home = $('._tdn3u').childNodes[0].childNodes[0]
   if (home) {
     home.click()
   }
 })
 
 ipcRenderer.on('navigate-discover', () => {
-  const discover = $('._n7q2c ._r1svv:nth-child(2) a')
+  const discover = $('._tdn3u').childNodes[1].childNodes[0]
+  console.log(discover)
   if (discover) {
     discover.click()
   }
 })
 
 ipcRenderer.on('navigate-upload', () => {
-  const upload = $('._n7q2c div._r1svv._gx3bg._tegto')
+  const upload = $('._tdn3u').childNodes[2]
   if (upload) {
     upload.click()
   }
 })
 
 ipcRenderer.on('navigate-notifications', () => {
-  const notifications = $('._n7q2c ._r1svv:nth-child(4) a')
+  const notifications = $('._tdn3u').childNodes[3].childNodes[0]
   if (notifications) {
     notifications.click()
   }
 })
 
 ipcRenderer.on('navigate-profile', () => {
-  const profile = $('._n7q2c ._r1svv:nth-child(5) a')
-  console.log(profile)
+  const profile = $('._tdn3u').childNodes[4].childNodes[0]
   if (profile) {
     profile.click()
   }
@@ -57,7 +50,7 @@ ipcRenderer.on('navigate-profile', () => {
 
 ipcRenderer.on('navigate-up', () => {
   if (post >= 1) {
-    var titles = document.getElementsByClassName('_h2d1o')
+    var titles = document.getElementsByClassName('_s5vjd')
     if (titles[post] != null) {
       post -= 1
       var rect = titles[post].getBoundingClientRect()
@@ -67,7 +60,7 @@ ipcRenderer.on('navigate-up', () => {
 })
 
 ipcRenderer.on('navigate-down', () => {
-  var titles = document.getElementsByClassName('_h2d1o')
+  var titles = document.getElementsByClassName('_s5vjd')
   if (titles[post + 1] != null) {
     post += 1
     var rect = titles[post].getBoundingClientRect()
@@ -104,21 +97,14 @@ function backHomeButton (location) {
   })
 }
 
-function login (elm) {
-  elm.addEventListener('click', (e) => {
-    elm.classList.toggle('goback')
-    process.nextTick(() => {
-      if (elm.classList.contains('goback')) {
-        elm.innerText = 'Go back'
-      } else {
-        elm.innerText = 'Log In'
-      }
-    })
-  })
-}
-
 function setDarkMode () {
   document.documentElement.classList.toggle('dark-mode', config.get('darkMode'))
+
+  if (document.documentElement.style.backgroundColor == 'rgb(25, 38, 51)') {
+    document.documentElement.style.backgroundColor = '#fff'
+  } else if (config.get('darkMode')) {
+    document.documentElement.style.backgroundColor = '#192633'
+  }
 }
 
 function fix404 () {
@@ -139,25 +125,13 @@ function fix404 () {
   backHomeButton('home')
 }
 
-function init () {
-  setDarkMode()
-
-  if (!$(selectors.notFoundPage)) {
-    backHomeButton('back')
-  }
-
-  // Prevent flash of white on startup when in dark mode
-  // TODO: Find solution to this with pure css
-  if (config.get('darkMode')) {
-    document.documentElement.style.backgroundColor = '#192633'
-  }
-}
-
 document.addEventListener('DOMContentLoaded', (event) => {
   // enable OS specific styles
   document.documentElement.classList.add(`os-${process.platform}`)
 
-  elementReady(selectors.notFoundPage).then(fix404)
-  elementReady(selectors.root).then(init)
-  elementReady(selectors.loginButton).then(login)
+  // Initialize darkMode settings
+  setDarkMode()
+
+  // Fix 404 pages
+  elementReady('.dialog-404').then(fix404)
 })

--- a/app/src/renderer/styles/core/_fixes.scss
+++ b/app/src/renderer/styles/core/_fixes.scss
@@ -1,18 +1,24 @@
-/* Scrollbar - currently hidden */
+/* Scrollbar */
 
-::-webkit-scrollbar {
-  width: 2px;
-  display: none;
+html::-webkit-scrollbar {
+  width: 8px;
 }
 
-::-webkit-scrollbar-track {
-  background-color: #fafafa;
+html::-webkit-scrollbar-track {
+  background-color: transparent;
 }
 
-::-webkit-scrollbar-thumb {
-  background-color: #000;
+html::-webkit-scrollbar-thumb {
+  background-color: #cbc9c9;
 }
 
+html::-webkit-scrollbar-thumb:hover {
+  background-color: #b0b0b0;
+}
+
+html::-webkit-scrollbar-thumb:active {
+  background-color: #9e9e9e;
+}
 
 /* Remove focus glow */
 

--- a/app/src/renderer/styles/core/_login.scss
+++ b/app/src/renderer/styles/core/_login.scss
@@ -1,8 +1,3 @@
-.not-logged-in body {
-  overflow: hidden;
-}
-
-
 /* Hide elements */
 
 #react-root {
@@ -119,4 +114,21 @@
 
 #react-root ._e0mru {
   box-shadow: none;
+}
+
+/**
+ * Fix Scrolling/Positioning
+ */
+
+/* Show scrollbar */
+
+#react-root ._29u45 {
+  overflow: visible;
+}
+
+/* Add bottom margin & remove border */
+
+#react-root main[role="main"] {
+  margin-bottom: 44px;
+  border-width: 0px;
 }

--- a/app/src/renderer/styles/core/_other.scss
+++ b/app/src/renderer/styles/core/_other.scss
@@ -26,3 +26,11 @@
 #react-root ._cbomp {
   left: 80px;
 }
+
+/**
+ * Hide "Open in app" button
+ */
+
+._jdrlj, ._t0se8 {
+  display: none;
+}

--- a/app/src/renderer/styles/core/_sidebar.scss
+++ b/app/src/renderer/styles/core/_sidebar.scss
@@ -20,12 +20,8 @@ Outdated
 /* Add sidebar */
 #react-root > section > nav {
   background-color: $light;
-  position: fixed;
-  left: 0;
   width: 80px;
   height: 100%;
-  border-right: 1px solid $sidebar-border;
-  will-change: left, top;
   display: block;
 }
 
@@ -33,8 +29,9 @@ Outdated
 #react-root > section > main {
   max-width: calc(100vw - 80px);
   position: relative;
-  left: 80px;
-  top: 44px;
+  left: 40px;
+  top: 22px;
+  margin-bottom: 88px;
 }
 
 

--- a/app/src/renderer/styles/theme-dark/_fixes.scss
+++ b/app/src/renderer/styles/theme-dark/_fixes.scss
@@ -1,15 +1,26 @@
+/* Scrollbar */
+
 html.dark-mode::-webkit-scrollbar-track {
-  background-color: $dark;
+  background-color: $darkLight;
 }
 
 html.dark-mode::-webkit-scrollbar-thumb {
-  background-color: $white;
+  background-color: #596b7d;
 }
+
+html.dark-mode::-webkit-scrollbar-thumb:hover {
+  background-color: #425466;
+}
+
+html.dark-mode::-webkit-scrollbar-thumb:active {
+  background-color: #364657;
+}
+
+/* React Root */
 
 html.dark-mode #react-root {
   color: $bright;
 }
-
 
 /* Main container */
 
@@ -75,20 +86,24 @@ html.dark-mode #react-root ._jveic {
 }
 
 
-/* time-stamp */
+/* time-stamp, location, paid partnership text */
 
-html.dark-mode #react-root ._ljyfo,
-html.dark-mode #react-root ._ljyfo:visited {
+html.dark-mode #react-root ._q8ysx,
+html.dark-mode #react-root ._q8ysx:visited,
+html.dark-mode #react-root ._6y8ij,
+html.dark-mode #react-root ._6y8ij:visited,
+html.dark-mode #react-root ._rnlnu,
+html.dark-mode ._nr3h3,
+html.dark-mode ._s7b66 {
   color: $gray;
 }
 
+/* Location Post Listing Text */
 
-/* location */
-
-html.dark-mode #react-root ._rnlnu {
-  color: $gray;
+html.dark-mode ._qkuz0,
+html.dark-mode ._52qm9 {
+  color: $white;
 }
-
 
 /* likes */
 
@@ -136,32 +151,17 @@ html.dark-mode #react-root header {
   }
 }
 
-
-
-
 /*Header text*/
 
 html.dark-mode ._tkl3w {
   color: #fafafa;
 }
 
-
-/*Unreadable text on the "Following" button*/
-
-html.dark-mode {
-  ._ah57t._6y2ah._i46jh._rmr7s,
-  ._ah57t._6y2ah._frcv2._rmr7s {
-    color: #fafafa;
-  }
-}
-
-
 /*Add a new photo*/
 
 html.dark-mode ._hxtsz {
   background-color: $dark;
 }
-
 
 /* Report a problem */
 
@@ -175,18 +175,32 @@ html.dark-mode {
   }
 }
 
-/*Title, Heart and Comment images*/
+/* Title(s), Heart, Dropdown Arrow, Close, and Comment images */
 
-html.dark-mode .coreSpriteHeartOpen,
-html.dark-mode .coreSpriteMobileNavTypeLogo,
-html.dark-mode .coreSpriteComment,
-html.dark-mode .coreSpriteOptionsEllipsis,
-html.dark-mode .coreSpriteMobileNavSettings {
-  filter: invert(100%);
+html.dark-mode {
+  .coreSpriteHeartOpen,
+  .coreSpriteMobileNavTypeLogo,
+  .coreSpriteComment,
+  .coreSpriteOptionsEllipsis,
+  .coreSpriteMobileNavSettings,
+  .coreSpriteDropdownArrowGrey9,
+  .coreSpriteLoggedOutWordmark,
+  .coreSpriteClose {
+    filter: invert(100%);
+  }
 }
 
-/*Likes count text*/
-html.dark-mode ._tf9x3 {
+/* Likes & Views count text */
+
+html.dark-mode {
+  ._nzn1h, ._m5zti {
+    color: $bright;
+  }
+}
+
+/* "and" & "like this" text (likes) */
+
+html.dark-mode ._3gwk6._nt9ow {
   color: $bright;
 }
 
@@ -197,4 +211,14 @@ html.dark-mode ._eskl6 {
 
 html.dark-mode ._s6yvg {
   border-color: $darkLight;
+}
+
+/* Text Input (e.g. comments) */
+
+html.dark-mode input,
+html.dark-mode textarea,
+html.dark-mode select {
+  border-color: $dark;
+  background-color: $darkLight;
+  color: $white;
 }

--- a/app/src/renderer/styles/theme-dark/_login.scss
+++ b/app/src/renderer/styles/theme-dark/_login.scss
@@ -1,11 +1,19 @@
-/* logo */
+html.dark-mode #react-root {
+  /* Panels */
+  ._kp5f7._qy55y, ._f9sjj, ._f9sjj {
+    color: $bright;
+    background-color: $dark;
+    border-color: $dark;
+  }
 
-html.dark-mode #react-root ._du7bh {
-  -webkit-filter: brightness(0) invert(1);
-}
+  /* "Have an account" & "Don't have an account" text */
+  ._c59vy {
+    color: $bright;
+  }
 
-html.dark-mode #react-root ._kp5f7._qy55y {
-  color: $bright;
-  background-color: $dark;
-  border-color: $dark;
+  /* Input fields */
+  ._sjplo {
+    border-color: $darkLight;
+    background-color: $darkLight;
+  }
 }

--- a/app/src/renderer/styles/theme-dark/_profile.scss
+++ b/app/src/renderer/styles/theme-dark/_profile.scss
@@ -5,7 +5,6 @@ html.dark-mode #react-root ._aj7mu._a89os {
   border-color: #303b47;
 }
 
-
 /* load more */
 
 //html.dark-mode #react-root ._1ooyk,
@@ -26,14 +25,14 @@ html.dark-mode #react-root ._1ooyk {
 
 /* username */
 
-html.dark-mode #react-root ._i572c {
+html.dark-mode #react-root ._rf3jb {
   color: $bright;
 }
 
 
 /* name */
 
-html.dark-mode #react-root ._79dar {
+html.dark-mode #react-root ._kc4z2 {
   color: $bright;
 }
 
@@ -52,13 +51,13 @@ html.dark-mode #react-root ._bugdy span {
 }
 
 
-/* followers, following */
+/* posts, followers, following */
 
 html.dark-mode #react-root {
-  ._bkw5z._kjym7,
-  ._s53mj._13vpi,
-  ._bkw5z,
-  ._s53mj {
+  ._fd86t._he56w,
+  ._fd86t._he56w,
+  ._fd86t._he56w,
+  ._qv64e._t78yp._4tgw8._njrw0 {
     color: $bright;
   }
 }
@@ -66,7 +65,12 @@ html.dark-mode #react-root {
 
 /* follow/following/edit profile buttons */
 
-html.dark-mode #react-root ._dzx3o {
+html.dark-mode #react-root ._qv64e._t78yp._r9b8f._njrw0 {
+  color: $bright;
+}
+
+/* Load More button */
+html.dark-mode #react-root ._1cr2e._epyes {
   color: $bright;
 }
 
@@ -80,29 +84,34 @@ html.dark-mode #react-root ._8gpiy {
 
 /* Private profile */
 
-html.dark-mode #react-root ._76rrx {
-  background-color: $darkLight;
-  border: none;
-}
+html.dark-mode #react-root {
+  ._q8pf2._r1mv3 {
+    background-color: $darkLight;
+    border: none;
+  }
 
-html.dark-mode #react-root ._76rrx h2,
-html.dark-mode #react-root ._76rrx p {
-  color: $bright;
+  ._q8pf2._r1mv3 {
+    h2, p {
+      color: $bright;
+    }
+  }
 }
 
 
 /*Suggested*/
 
-html.dark-mode #react-root ._3p78u._28ejm._go7te._pn9fv::before {
-  background-color: $dark;
-  border-left: 1px solid rgba(80, 80, 80, .2);
-  border-top: 1px solid rgba(80, 80, 80, .2);
-}
+html.dark-mode #react-root {
+  ._gwyj6._66ugs._7djd0._dah1q._hqhuc::before,
+  ._gwyj6._66ugs._7djd0._dah1q._hqhuc {
+    background-color: $dark;
+    border-left: 1px solid rgba(80, 80, 80, .2);
+    border-top: 1px solid rgba(80, 80, 80, .2);
+  }
 
-html.dark-mode #react-root ._3p78u._28ejm._go7te._pn9fv {
-  background-color: $dark;
-  border-top: 1px solid rgba(80, 80, 80, .2);
-  border-bottom: 1px solid rgba(80, 80, 80, .2);
+  ._gwyj6._66ugs._7djd0._dah1q._hqhuc div {
+    background-color: $dark;
+    border-color: rgba(80, 80, 80, .2);
+  }
 }
 
 
@@ -140,15 +149,15 @@ html.dark-mode #react-root ._379kp {
 
 /* text */
 
-html.dark-mode #react-root ._auspy {
+html.dark-mode #react-root ._b96u5 {
   color: $bright;
 }
 
 
 /* border */
 
-html.dark-mode #react-root ._mkiio::after {
-  border-color: $darkLight;
+html.dark-mode #react-root ._75ljm._3qhgf::after {
+  border-color: $dark;
 }
 
 
@@ -156,12 +165,12 @@ html.dark-mode #react-root ._mkiio::after {
  * Tableviews (Following, Followers)
  */
 
-html.dark-mode #react-root ._q44m8 {
+html.dark-mode #react-root ._lfwfo {
   background-color: $dark;
   color: $bright;
 }
 
-html.dark-mode #react-root ._cx1ua {
+html.dark-mode #react-root ._q2d5a._b9n99 {
   background-color: $dark;
   border-color: $darkLight;
 }
@@ -171,66 +180,54 @@ html.dark-mode #react-root ._cx1ua {
  * Edit profile page
  */
 
-html.dark-mode #react-root ._40h7m {
-  background-color: $dark;
-}
-
-
 /* Settings */
 
-html.dark-mode #react-root ._jkiz5 {
-  background-color: $dark;
-  ._kn3uh {
-    background-color: $darkLight;
-    border-color: $gray;
-    span,
-    a {
-      color: $blue;
+html.dark-mode #react-root {
+  ._rqmce, ._rqmce div {
+    background-color: $dark;
+    border-color: $darkLight;
+  }
+
+  ._rqmce span {
+    color: $white;
+  }
+}
+
+/* Edit Profile */
+
+html.dark-mode #react-root {
+  ._75z9k {
+    background-color: $dark;
+  }
+
+  ._75z9k label {
+    color: white;
+  }
+}
+
+/* Report Problem */
+
+html.dark-mode {
+  ._rx4nb {
+    background-color: $dark;
+  }
+
+  ._rx4nb {
+    h1, p, ._qv64e._t78yp._4tgw8._njrw0 {
+      color: $bright;
     }
   }
-  ._81dcm {
+}
+
+/* Locations */
+
+html.dark-mode #react-root ._775gj {
+  ._cem40 {
+    background-color: $dark;
+  }
+
+  ._brnf8 {
     border-color: $gray;
+    background-color: $darkLight;
   }
-}
-
-html.dark-mode #react-root ._e5cd3 {
-  h2._aoi9w,
-  p._m2kht,
-  h2._bgfey,
-  div._j0kjj,
-  div._8unkm {
-    color: $bright;
-  }
-}
-
-
-/* label */
-
-html.dark-mode #react-root ._891mt {
-  color: $bright;
-}
-
-
-/* private label */
-
-html.dark-mode #react-root ._bgfey {
-  color: $gray;
-}
-
-
-/* inputs */
-html.dark-mode #react-root {
-  ._2j83n, ._9pfjt, ._g6a4a,._cmoxu ._qy55y,
-  ._1n8j5._qy55y {
-    background-color: #303b47;
-    border: none;
-    color: $bright;
-  }
-}
-
-
-/* terms */
-
-html.dark-mode #react-root ._lxlnj {
-  color: $bright;
 }

--- a/app/src/renderer/styles/theme-dark/_search.scss
+++ b/app/src/renderer/styles/theme-dark/_search.scss
@@ -1,48 +1,31 @@
-/* discover text */
-
-html.dark-mode #react-root ._bgfey {
-  color: $gray;
-}
-
-
-/* search field bg */
-
-html.dark-mode #react-root ._oyz6j {
-  background-color: $dark;
-}
-
-
-/* search field hover */
-
-html.dark-mode #react-root ._xk9bu {
-  background-color: $darkLight;
-}
-
-
 /* seach field */
 
-html.dark-mode #react-root ._9x5sw,
-html.dark-mode #react-root ._55bi1 {
+html.dark-mode #react-root ._jcvs2._kjnbr {
   color: $bright;
   background-color: #303b47;
   border-color: #303b47;
 }
 
-
-/* input border */
-
-html.dark-mode #react-root ._55bi1,
-html.dark-mode #react-root ._48qwd {
-  border-color: #303b47;
-}
-
-
 /* search drop-down */
 
-html.dark-mode #react-root ._o1o4h {
+html.dark-mode #react-root ._etpgz {
   background-color: $dark;
   box-shadow: 0 0 5px rgba(0, 0, 0, .85);
   border-color: $darkLight;
+}
+
+html.dark-mode #react-root ._etpgz {
+  ._gimca {
+    border-color: $darkLight;
+  }
+
+  ._5tsk5 {
+    background: $darkLight;
+  }
+
+  span {
+    color: $bright;
+  }
 }
 
 html.dark-mode #react-root ._o1o4h::after {
@@ -66,9 +49,7 @@ html.dark-mode #react-root ._k2vj6 span {
   color: $gray;
 }
 
-
-/* border ul top */
-
-html.dark-mode #react-root ._769lo {
-  border-color: $darkLight;
+/* item container */
+html.dark-mode #react-root ._lq68t._bk5sx {
+  background-color: $dark;
 }

--- a/app/src/renderer/styles/theme-dark/_sidebar.scss
+++ b/app/src/renderer/styles/theme-dark/_sidebar.scss
@@ -1,19 +1,24 @@
-html.dark-mode #react-root ._onabe._kjy2s {
-  background-color: $darkLight;
-  border-right: 1px solid rgba(255, 255, 255, .08);
-}
-
-html.dark-mode #react-root ._bfc7q {
+html.dark-mode #react-root main {
   background-color: $darkLight;
 }
 
-html.dark-mode #react-root ._r1svv {
+html.dark-mode #react-root header,
+html.dark-mode #react-root ._f4a0g {
+  background-color: $darkLight;
+}
+
+html.dark-mode #react-root header._7b8eu._9dpug {
+  border-color: $darkLight;
+}
+
+html.dark-mode #react-root .coreSpriteMobileNavAddPeopleInactive {
   -webkit-filter: brightness(0) invert(1);
 }
 
-html.dark-mode.os-macos .back-btn{
+html.dark-mode.os-macos .back-btn {
   border-top: 1px solid rgba(255, 255, 255, 0.0784314);
 }
+
 html.dark-mode .back-btn {
   border-bottom: 1px solid rgba(255, 255, 255, 0.0784314);
   background-color: rgb(32, 44, 58);
@@ -25,4 +30,16 @@ html.dark-mode .back-btn svg {
 
 html.dark-mode .back-btn.inactive svg {
   fill: rgba(255, 255, 255, 0.2);
+}
+
+/* Change background color */
+
+html.dark-mode #react-root ._tdn3u {
+  background-color: $darkLight;
+}
+
+/* Invert icon colors */
+
+html.dark-mode #react-root ._crp8c {
+  filter: invert(100%);
 }


### PR DESCRIPTION
* Fix Dark mode (outdated class references - fixes anything that remained from #171)
* Make dark mode menu item a checkbox
* Fix initializer functions in `renderer/js/index.js`
* Improve dark mode toggle to not require a page reload
* Re-add scrollbar
* Allow scrolling in login screen (fixes #177)
* Hide "Open in app" button
* Remove sidebar gap and use default Instagram navigation (temporary)
* Remove Zoom menu entries (cause application crashes and CSS issues - not worth fixing at the time)

The only thing this PR does that could possibly be controversial, is drop the custom navigation previously seen in Ramme. I couldn't make sense of the CSS with the outdated classes, so I figured that it would be best to just use the default Instagram navigation for now, and to then modify the dark mode CSS to work with it. In the future, I'd be very happy to see the custom navigation reimplemented, but I think this should happen together with a total redesign of the app.

There's a lot more invalid CSS that *could* be removed, however, I didn't think it was worth doing in this PR as my main focus was to simply make sure that the app was usable.