### PR TITLE
Fix issue with Back keyboard shortcut

### DIFF
--- a/app/src/main/menus.js
+++ b/app/src/main/menus.js
@@ -7,6 +7,7 @@ const win = BrowserWindow.getAllWindows()[0]
 const appName = app.getName()
 
 function sendAction (action) {
+  const win = BrowserWindow.getAllWindows()[0]
   if (isPlatform('macOS')) {
     win.restore()
   }


### PR DESCRIPTION
When running, the global constant of 'win' for the menus doesn't contain anything. Copying reference to all the windows inside of the send action will guarantee there is a window to restore.