### PR TITLE
Fixed a small typo in the devDepdency declaration for gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "electron": "^2.0.3",
     "electron-builder": "^20.18.0",
     "eslint-import-resolver-node": "^0.3.2",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "github:gulpjs/gulp#v4.0.0",
     "gulp-autoprefixer": "^5.0.0",
     "gulp-babel": "^7.0.1",
     "gulp-image": "^4.3.0",


### PR DESCRIPTION
Hey guys,

Thanks for supporting this fantastic application! 

After cloning, I tried running `npm install` and ran into this error:

```
➜ npm install
npm ERR! code 1
npm ERR! Command failed: /usr/local/bin/git checkout 4.0
npm ERR! error: pathspec '4.0' did not match any file(s) known to git.
npm ERR!

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/USER/.npm/_logs/20*******debug.log
```